### PR TITLE
feat: define enforce schema function

### DIFF
--- a/consistent_df/__init__.py
+++ b/consistent_df/__init__.py
@@ -4,6 +4,7 @@
 used across multiple modules, promoting code reuse and consistency across multiple modules."""
 
 from .enforce_dtypes import enforce_dtypes
+from .enforce_schema import enforce_schema
 from .nest import nest, unnest
 from .string import df_to_consistent_str
 from .testing import assert_frame_equal

--- a/consistent_df/enforce_dtypes.py
+++ b/consistent_df/enforce_dtypes.py
@@ -68,7 +68,7 @@ def enforce_dtypes(
 
         missing_cols = [col for col in required if col not in data.columns]
         if missing_cols:
-            raise ValueError(f"Input DataFrame is missing required columns: {missing_cols}")
+            raise ValueError(f"Data frame is missing required columns: {missing_cols}")
 
         for col, dtype in all_cols.items():
             if col not in data:

--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -8,15 +8,13 @@ import pandas as pd
 def enforce_schema(
     data: pd.DataFrame,
     schema: pd.DataFrame,
-    keep_extra_columns: bool = False
+    keep_extra_columns: bool = False,
+    sort_columns: bool = False
 ) -> pd.DataFrame:
     """Enforce presence and data types of DataFrame columns.
 
     This function ensures that required columns are present, adds missing optional columns,
-    enforces the specified data types, and orders the columns as defined by the schema.
-
-    Existing required and optional columns are converted to specified dtypes,
-    leading to an error if type conversion fails.
+    enforces the specified data types.
 
     Args:
         data (pd.DataFrame | None): The DataFrame to validate and transform.
@@ -27,6 +25,8 @@ def enforce_schema(
               or optional (False). If missing, all columns are considered mandatory.
         keep_extra_columns (bool): If True, columns not listed in the schema are retained.
                                    If False, only columns defined in the schema will be kept.
+        sort_columns (bool): If True, columns will be ordered as per the schema. If False,
+                             the original column order is retained.
 
     Returns:
         pd.DataFrame: Transformed DataFrame adhering to the schema.
@@ -52,7 +52,6 @@ def enforce_schema(
     """
 
     required_schema_columns = {"column", "dtype"}
-
     if not isinstance(schema, pd.DataFrame):
         raise TypeError("Schema must be a pandas DataFrame.")
     if not required_schema_columns.issubset(schema.columns):
@@ -105,9 +104,11 @@ def enforce_schema(
 
         if not keep_extra_columns:
             data = data[[col for col in data.columns if col in schema["column"].to_list()]]
-        data = data[
-            schema["column"].to_list()
-            + data.columns[~data.columns.isin(schema["column"].to_list())].tolist()
-        ]
+
+        if sort_columns:
+            data = data[
+                schema["column"].to_list()
+                + data.columns[~data.columns.isin(schema["column"].to_list())].tolist()
+            ]
 
     return data

--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -1,8 +1,17 @@
 """Module to enforce column schemas in pandas DataFrames."""
 
 import re
+from io import StringIO
 from zoneinfo import ZoneInfo
 import pandas as pd
+
+SCHEMA_CSV = """
+    column,         dtype,     mandatory
+    column,         str,       True
+    dtype,          str,       True
+    mandatory,      bool,      False
+"""
+SCHEMA = pd.read_csv(StringIO(SCHEMA_CSV), skipinitialspace=True)
 
 
 def enforce_schema(
@@ -11,104 +20,99 @@ def enforce_schema(
     keep_extra_columns: bool = False,
     sort_columns: bool = False
 ) -> pd.DataFrame:
-    """Enforce presence and data types of DataFrame columns.
+    """Enforce schema and type consistency in a pandas DataFrame.
 
-    This function ensures that required columns are present, adds missing optional columns,
-    enforces the specified data types.
+    This function ensures that a DataFrame adheres to a specified schema by
+    verifying the presence of required columns, adding missing optional columns,
+    and converting columns to the specified data types.
+
+    Behavior with empty input:
+    - If the input data is None, the function returns an empty DataFrame with all
+    required and optional columns from the schema.
+    - If the input data is an empty DataFrame, missing required columns are
+    added without raising an error.
 
     Args:
-        data (pd.DataFrame | None): The DataFrame to validate and transform.
-        schema (pd.DataFrame): A DataFrame defining the schema. It must include:
+        data (pd.DataFrame | None): The DataFrame to validate and adjust.
+        schema (pd.DataFrame): A DataFrame defining the schema, with the following columns:
             - "column": Name of the column.
             - "dtype": Expected data type (e.g., "int64", "float64", "datetime64[ns]").
-            - "mandatory" (optional): Boolean flag indicating if the column is required (True)
-              or optional (False). If missing, all columns are considered mandatory.
-        keep_extra_columns (bool): If True, columns not listed in the schema are retained.
-                                   If False, only columns defined in the schema will be kept.
-        sort_columns (bool): If True, columns will be ordered as per the schema. If False,
-                             the original column order is retained.
+            - "mandatory" (optional): Boolean flag indicating whether the column
+            is required (True) or optional (False). If not provided, all columns
+            are considered mandatory by default.
+        keep_extra_columns (bool): If True, columns that are not listed in the schema are retained.
+        sort_columns (bool): If True, columns are sorted in the order of appearance in the schema.
 
     Returns:
-        pd.DataFrame: Transformed DataFrame adhering to the schema.
+        pd.DataFrame: A DataFrame that conforms to the schema.
 
     Raises:
-        ValueError: If the input DataFrame is missing required columns, or the schema has missing
-                    or invalid dtype values.
-        TypeError: If the input data is not a pandas DataFrame or None,
-                   or if dtype conversion fails.
+        ValueError: If required columns are missing from the input DataFrame.
+        TypeError: If the data or schema is not a pandas DataFrame, or if a
+                data type conversion fails.
 
     Example:
-        >>> PRICE_SCHEMA_CSV = \"\"\"
-        ... column,             dtype,                mandatory
-        ... ticker,             string[python],       True
-        ... price,              Float64,              True
+        >>> schema_csv = \"\"\"
+        ... column,         dtype,     mandatory
+        ... ticker,         string,    True
+        ... price,          Float64,   True
         ... \"\"\"
-        >>> PRICE_SCHEMA = pd.read_csv(StringIO(PRICE_SCHEMA_CSV), skipinitialspace=True)
-        >>> df = pd.DataFrame({'ticker': ['AAPL', 'GOOGL'], 'price': [150.0, 2800.0]})
-        >>> enforce_schema(df, PRICE_SCHEMA)
-           ticker  price
+        >>> schema = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+        >>> data = pd.DataFrame({'ticker': ['AAPL', 'GOOGL'], 'price': [150.0, 2800.0]})
+        >>> enforce_schema(data, schema)
+        ticker  price
         0    AAPL  150.0
         1   GOOGL  2800.0
     """
-
-    required_schema_columns = {"column", "dtype"}
     if not isinstance(schema, pd.DataFrame):
         raise TypeError("Schema must be a pandas DataFrame.")
-    if not required_schema_columns.issubset(schema.columns):
-        raise ValueError(f"Schema is missing required columns: {required_schema_columns}")
     if not isinstance(data, pd.DataFrame) and data is not None:
         raise TypeError("Data must be a pandas DataFrame or None.")
-
-    # Default all columns to mandatory if 'mandatory' column is not present
     if "mandatory" not in schema.columns:
         schema["mandatory"] = True
-
+    schema = _enforce_schema(schema, SCHEMA)
     if data is None:
-        data = pd.DataFrame(
-            {col: pd.Series(dtype=dtype) for col, dtype in zip(schema["column"], schema["dtype"])}
-        )
-    else:
-        if data.empty:
-            for col, dtype in zip(schema["column"], schema["dtype"]):
-                data[col] = pd.Series(dtype=dtype)
+        data = pd.DataFrame(columns=schema["column"])
+    result = _enforce_schema(data=data, schema=schema)
+    if not keep_extra_columns:
+        result = result[result.columns[result.columns.isin(schema["column"])]]
+    if sort_columns:
+        cols = (schema["column"].to_list()
+                + data.columns[~data.columns.isin(schema["column"])].to_list())
+        result = result[cols]
+    return result
 
+
+def _enforce_schema(data: pd.DataFrame, schema: pd.DataFrame) -> pd.DataFrame:
+
+    if not data.empty:
         missing_cols = set(schema.loc[schema["mandatory"], "column"]).difference(data.columns)
         if missing_cols:
-            raise ValueError(f"Input DataFrame is missing required columns: {missing_cols}")
+            raise ValueError(f"Data frame is missing required columns: {missing_cols}")
 
-        for col, dtype in zip(schema["column"], schema["dtype"]):
-            if col not in data:
-                data[col] = pd.Series(dtype=dtype)
-            else:
-                if dtype.startswith("datetime64"):
-                    if re.fullmatch("datetime64\\[ns\\]", dtype):
-                        timezone = None
-                    elif re.fullmatch("datetime64\\[ns, .+\\]", dtype):
-                        timezone_str = dtype.split(",")[1][:-1].strip()
-                        timezone = ZoneInfo(timezone_str)
-                    else:
-                        raise ValueError(f"Unknown datetime dtype: '{dtype}'.")
-                    try:
-                        data[col] = pd.to_datetime(data[col])
-                    except pd._libs.tslibs.parsing.DateParseError as e:
-                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
-                    if data[col].dt.tz is None:
-                        data[col] = data[col].dt.tz_localize(timezone)
-                    else:
-                        data[col] = data[col].dt.tz_convert(timezone)
+    for col, dtype in zip(schema["column"], schema["dtype"]):
+        if col not in data:
+            data[col] = pd.Series(dtype=dtype)
+        else:
+            if dtype.startswith("datetime64"):
+                if re.fullmatch("datetime64\\[ns\\]", dtype):
+                    timezone = None
+                elif re.fullmatch("datetime64\\[ns, .+\\]", dtype):
+                    timezone_str = dtype.split(",")[1][:-1].strip()
+                    timezone = ZoneInfo(timezone_str)
                 else:
-                    try:
-                        data[col] = data[col].astype(dtype)
-                    except (TypeError, ValueError) as e:
-                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
-
-        if not keep_extra_columns:
-            data = data[[col for col in data.columns if col in schema["column"].to_list()]]
-
-        if sort_columns:
-            data = data[
-                schema["column"].to_list()
-                + data.columns[~data.columns.isin(schema["column"].to_list())].tolist()
-            ]
-
+                    raise ValueError(f"Unknown datetime dtype: '{dtype}'.")
+                try:
+                    data[col] = pd.to_datetime(data[col])
+                except pd._libs.tslibs.parsing.DateParseError as e:
+                    raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
+                if data[col].dt.tz is None:
+                    data[col] = data[col].dt.tz_localize(timezone)
+                else:
+                    data[col] = data[col].dt.tz_convert(timezone)
+            else:
+                try:
+                    data[col] = data[col].astype(dtype)
+                except (TypeError, ValueError) as e:
+                    raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
     return data

--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -1,9 +1,10 @@
 """Module to enforce column schemas in pandas DataFrames."""
 
 import re
+import pandas as pd
 from io import StringIO
 from zoneinfo import ZoneInfo
-import pandas as pd
+
 
 SCHEMA_CSV = """
     column,         dtype,     mandatory
@@ -17,8 +18,8 @@ SCHEMA = pd.read_csv(StringIO(SCHEMA_CSV), skipinitialspace=True)
 def enforce_schema(
     data: pd.DataFrame,
     schema: pd.DataFrame,
+    sort_columns: bool = False,
     keep_extra_columns: bool = False,
-    sort_columns: bool = False
 ) -> pd.DataFrame:
     """Enforce schema and type consistency in a pandas DataFrame.
 
@@ -84,7 +85,6 @@ def enforce_schema(
 
 
 def _enforce_schema(data: pd.DataFrame, schema: pd.DataFrame) -> pd.DataFrame:
-
     if not data.empty:
         missing_cols = set(schema.loc[schema["mandatory"], "column"]).difference(data.columns)
         if missing_cols:

--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -1,0 +1,122 @@
+import re
+from zoneinfo import ZoneInfo
+import pandas as pd
+
+
+def enforce_schema(
+    data: pd.DataFrame,
+    schema: pd.DataFrame,
+    keep_extra_columns: bool = False
+) -> pd.DataFrame:
+    """Ensures that a DataFrame adheres to a specified column schema, enforcing
+    the presence and data types of specified columns.
+
+    This function validates and adjusts a DataFrame to follow a predefined schema.
+    The schema is provided as a separate DataFrame, where each row specifies a column name,
+    its required data type, and whether it's mandatory. It guarantees that required columns
+    are present, adds optional columns if missing, ensures the correct data types, and orders
+    the columns as defined in the schema.
+
+    If `data` is:
+    - None: Returns an empty DataFrame with required and optional columns.
+    - an empty DataFrame: Adds missing required and optional columns.
+    - a DataFrame with one or more columns: Adds missing optional columns, and
+      raises an exception if any required columns are missing.
+
+    Existing required and optional columns are converted to specified dtypes,
+    leading to an error if type conversion fails.
+
+    Args:
+        data (pd.DataFrame | None): The DataFrame to validate and transform.
+        schema (pd.DataFrame): A DataFrame defining the schema. It must include:
+            - 'column_name': Name of the column.
+            - 'dtype': Expected data type (e.g., 'int64', 'float64', 'datetime64[ns]').
+            - 'mandatory': Boolean flag indicating if the column
+                           is required (True) or optional (False).
+        keep_extra_columns (bool): If True, columns not listed in the schema are retained.
+                                   If False, only columns defined in the schema will be kept.
+
+    Returns:
+        pd.DataFrame: A DataFrame with type-consistent columns and order.
+
+    Raises:
+        ValueError: If the input DataFrame is not empty and is missing any
+                    required columns.
+        TypeError: If the input data is not a pandas DataFrame or None, or
+                   if dtype conversion fails due to incompatible types.
+        ValueError: If the schema has missing or invalid dtype values.
+
+    Example:
+        >>> PRICE_SCHEMA_CSV = \"\"\"
+        ... column_name,        dtype,                mandatory
+        ... ticker,             string[python],       True
+        ... date,               datetime64[ns],       True
+        ... currency,           string[python],       True
+        ... price,              Float64,              True
+        ... \"\"\"
+        >>> PRICE_SCHEMA = pd.read_csv(StringIO(PRICE_SCHEMA_CSV), skipinitialspace=True)
+        >>> df = pd.DataFrame({'ticker': ['AAPL', 'GOOGL'], 'price': [150.0, 2800.0]})
+        >>> enforce_schema(df, PRICE_SCHEMA)
+           ticker  date currency  price
+        0   AAPL   NaT      NaN   150.0
+        1  GOOGL   NaT      NaN  2800.0
+    """
+
+    required_schema_columns = {"column_name", "dtype", "mandatory"}
+    if not isinstance(schema, pd.DataFrame):
+        raise TypeError("Schema must be a pandas DataFrame.")
+    if not required_schema_columns.issubset(schema.columns):
+        raise ValueError(f"Schema is missing required columns: {required_schema_columns}")
+
+    schema = schema.set_index("column_name")
+    required = schema.loc[schema["mandatory"], 'dtype'].to_dict()
+    optional = schema.loc[~schema["mandatory"], 'dtype'].to_dict()
+    all_cols = {**required, **optional}
+
+    if not isinstance(data, pd.DataFrame) and data is not None:
+        raise TypeError("Data must be a pandas DataFrame or None.")
+
+    all_cols = {**required, **optional}
+
+    if data is None:
+        data = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in all_cols.items()})
+    else:
+        if data.empty:
+            for col, dtype in all_cols.items():
+                data[col] = pd.Series(dtype=dtype)
+
+        missing_cols = [col for col in required if col not in data.columns]
+        if missing_cols:
+            raise ValueError(f"Input DataFrame is missing required columns: {missing_cols}")
+
+        for col, dtype in all_cols.items():
+            if col not in data:
+                data[col] = pd.Series(dtype=dtype)
+            else:
+                if dtype.startswith("datetime64"):
+                    if re.fullmatch("datetime64\\[ns\\]", dtype):
+                        timezone = None
+                    elif re.fullmatch("datetime64\\[ns, .+\\]", dtype):
+                        timezone_str = dtype.split(",")[1][:-1].strip()
+                        timezone = ZoneInfo(timezone_str)
+                    else:
+                        raise ValueError(f"Unknown datetime dtype: '{dtype}'.")
+                    try:
+                        data[col] = pd.to_datetime(data[col])
+                    except pd._libs.tslibs.parsing.DateParseError as e:
+                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
+                    if data[col].dt.tz is None:
+                        data[col] = data[col].dt.tz_localize(timezone)
+                    else:
+                        data[col] = data[col].dt.tz_convert(timezone)
+                else:
+                    try:
+                        data[col] = data[col].astype(dtype)
+                    except (TypeError, ValueError) as e:
+                        raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
+
+        if not keep_extra_columns:
+            data = data[[col for col in data.columns if col in all_cols]]
+        data = data[schema.index.tolist() + data.columns[~data.columns.isin(schema.index)].tolist()]
+
+    return data

--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -1,3 +1,5 @@
+"""Module to enforce column schemas in pandas DataFrames."""
+
 import re
 from zoneinfo import ZoneInfo
 import pandas as pd
@@ -8,20 +10,10 @@ def enforce_schema(
     schema: pd.DataFrame,
     keep_extra_columns: bool = False
 ) -> pd.DataFrame:
-    """Ensures that a DataFrame adheres to a specified column schema, enforcing
-    the presence and data types of specified columns.
+    """Enforce presence and data types of DataFrame columns.
 
-    This function validates and adjusts a DataFrame to follow a predefined schema.
-    The schema is provided as a separate DataFrame, where each row specifies a column name,
-    its required data type, and whether it's mandatory. It guarantees that required columns
-    are present, adds optional columns if missing, ensures the correct data types, and orders
-    the columns as defined in the schema.
-
-    If `data` is:
-    - None: Returns an empty DataFrame with required and optional columns.
-    - an empty DataFrame: Adds missing required and optional columns.
-    - a DataFrame with one or more columns: Adds missing optional columns, and
-      raises an exception if any required columns are missing.
+    This function ensures that required columns are present, adds missing optional columns,
+    enforces the specified data types, and orders the columns as defined by the schema.
 
     Existing required and optional columns are converted to specified dtypes,
     leading to an error if type conversion fails.
@@ -29,67 +21,63 @@ def enforce_schema(
     Args:
         data (pd.DataFrame | None): The DataFrame to validate and transform.
         schema (pd.DataFrame): A DataFrame defining the schema. It must include:
-            - 'column_name': Name of the column.
-            - 'dtype': Expected data type (e.g., 'int64', 'float64', 'datetime64[ns]').
-            - 'mandatory': Boolean flag indicating if the column
-                           is required (True) or optional (False).
+            - "column": Name of the column.
+            - "dtype": Expected data type (e.g., "int64", "float64", "datetime64[ns]").
+            - "mandatory" (optional): Boolean flag indicating if the column is required (True)
+              or optional (False). If missing, all columns are considered mandatory.
         keep_extra_columns (bool): If True, columns not listed in the schema are retained.
                                    If False, only columns defined in the schema will be kept.
 
     Returns:
-        pd.DataFrame: A DataFrame with type-consistent columns and order.
+        pd.DataFrame: Transformed DataFrame adhering to the schema.
 
     Raises:
-        ValueError: If the input DataFrame is not empty and is missing any
-                    required columns.
-        TypeError: If the input data is not a pandas DataFrame or None, or
-                   if dtype conversion fails due to incompatible types.
-        ValueError: If the schema has missing or invalid dtype values.
+        ValueError: If the input DataFrame is missing required columns, or the schema has missing
+                    or invalid dtype values.
+        TypeError: If the input data is not a pandas DataFrame or None,
+                   or if dtype conversion fails.
 
     Example:
         >>> PRICE_SCHEMA_CSV = \"\"\"
-        ... column_name,        dtype,                mandatory
+        ... column,             dtype,                mandatory
         ... ticker,             string[python],       True
-        ... date,               datetime64[ns],       True
-        ... currency,           string[python],       True
         ... price,              Float64,              True
         ... \"\"\"
         >>> PRICE_SCHEMA = pd.read_csv(StringIO(PRICE_SCHEMA_CSV), skipinitialspace=True)
         >>> df = pd.DataFrame({'ticker': ['AAPL', 'GOOGL'], 'price': [150.0, 2800.0]})
         >>> enforce_schema(df, PRICE_SCHEMA)
-           ticker  date currency  price
-        0   AAPL   NaT      NaN   150.0
-        1  GOOGL   NaT      NaN  2800.0
+           ticker  price
+        0    AAPL  150.0
+        1   GOOGL  2800.0
     """
 
-    required_schema_columns = {"column_name", "dtype", "mandatory"}
+    required_schema_columns = {"column", "dtype"}
+
     if not isinstance(schema, pd.DataFrame):
         raise TypeError("Schema must be a pandas DataFrame.")
     if not required_schema_columns.issubset(schema.columns):
         raise ValueError(f"Schema is missing required columns: {required_schema_columns}")
-
-    schema = schema.set_index("column_name")
-    required = schema.loc[schema["mandatory"], 'dtype'].to_dict()
-    optional = schema.loc[~schema["mandatory"], 'dtype'].to_dict()
-    all_cols = {**required, **optional}
-
     if not isinstance(data, pd.DataFrame) and data is not None:
         raise TypeError("Data must be a pandas DataFrame or None.")
 
-    all_cols = {**required, **optional}
+    # Default all columns to mandatory if 'mandatory' column is not present
+    if "mandatory" not in schema.columns:
+        schema["mandatory"] = True
 
     if data is None:
-        data = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in all_cols.items()})
+        data = pd.DataFrame(
+            {col: pd.Series(dtype=dtype) for col, dtype in zip(schema["column"], schema["dtype"])}
+        )
     else:
         if data.empty:
-            for col, dtype in all_cols.items():
+            for col, dtype in zip(schema["column"], schema["dtype"]):
                 data[col] = pd.Series(dtype=dtype)
 
-        missing_cols = [col for col in required if col not in data.columns]
+        missing_cols = set(schema.loc[schema["mandatory"], "column"]).difference(data.columns)
         if missing_cols:
             raise ValueError(f"Input DataFrame is missing required columns: {missing_cols}")
 
-        for col, dtype in all_cols.items():
+        for col, dtype in zip(schema["column"], schema["dtype"]):
             if col not in data:
                 data[col] = pd.Series(dtype=dtype)
             else:
@@ -116,7 +104,10 @@ def enforce_schema(
                         raise type(e)(f"Failed to convert '{col}' to {dtype}: {e}")
 
         if not keep_extra_columns:
-            data = data[[col for col in data.columns if col in all_cols]]
-        data = data[schema.index.tolist() + data.columns[~data.columns.isin(schema.index)].tolist()]
+            data = data[[col for col in data.columns if col in schema["column"].to_list()]]
+        data = data[
+            schema["column"].to_list()
+            + data.columns[~data.columns.isin(schema["column"].to_list())].tolist()
+        ]
 
     return data

--- a/tests/test_enforce_schema.py
+++ b/tests/test_enforce_schema.py
@@ -1,0 +1,178 @@
+"""Unit tests for enforcing DataFrame column schema with enforce_schema()."""
+
+from zoneinfo import ZoneInfo
+from consistent_df import enforce_schema
+import pandas as pd
+import pytest
+from io import StringIO
+
+
+def test_schema_is_not_dataframe():
+    df = pd.DataFrame({"Column1": [1, 2]})
+    schema = None
+    with pytest.raises(TypeError, match="Schema must be a pandas DataFrame."):
+        enforce_schema(df, schema)
+
+    # Test with an invalid schema type
+    schema = {"column_name": "Column1", "dtype": "int64", "mandatory": True}
+    with pytest.raises(TypeError, match="Schema must be a pandas DataFrame."):
+        enforce_schema(df, schema)
+
+
+def test_schema_missing_required_columns():
+    df = pd.DataFrame({"Column1": [1, 2]})
+    schema_csv = """
+        column_name,        dtype
+        Column1,            int64
+    """
+    schema = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    with pytest.raises(ValueError, match="Schema is missing required columns"):
+        enforce_schema(df, schema)
+
+
+def test_schema_invalid_dtype():
+    df = pd.DataFrame({"Column1": [1, 2]})
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            ,                    True
+    """
+    schema = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    with pytest.raises(AttributeError):
+        enforce_schema(df, schema)
+
+
+def test_empty_input():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Column2,            float64,              False
+        Date,               datetime64[ns],       False
+        Column3,            object,               False
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    result = enforce_schema(None, SAMPLE_SCHEMA)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == ["Column1", "Column2", "Date", "Column3"]
+
+
+def test_required_columns_added():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Column2,            float64,              True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    result = enforce_schema(None, SAMPLE_SCHEMA)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == ["Column1", "Column2"]
+    assert result["Column1"].dtype == "int64"
+    assert result["Column2"].dtype == "float64"
+
+
+def test_optional_columns_added():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Column2,            float64,              False
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": [1]})
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+    assert list(result.columns) == ["Column1", "Column2"]
+    assert result["Column2"].dtype == "float64"
+
+
+def test_missing_required_columns():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column3": ["data"]})
+    with pytest.raises(ValueError):
+        enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+
+
+def test_keep_extra_columns():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": [1], "Column3": ["extra"]})
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA, keep_extra_columns=False)
+    assert "Column3" not in result.columns
+    assert list(result.columns) == ["Column1"]
+
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA, keep_extra_columns=True)
+    assert "Column3" in result.columns
+    assert list(result.columns) == ["Column1", "Column3"]
+
+
+def test_dtype_conversion():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Column2,            float64,              False
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": ["1", "2", "3"], "Column2": ["1.1", "2.2", "3.3"]})
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+    assert result["Column1"].dtype == "int64"
+    assert result["Column2"].dtype == "float64"
+
+
+def test_invalid_dtype_conversion():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Column2,            float64,              False
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": ["invalid"], "Column2": ["data"]})
+    with pytest.raises(ValueError, match="^Failed to convert 'Column1' to int64:"):
+        enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+
+
+def test_datetime_without_timezone():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Date,               datetime64[ns],       True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": [1, 2], "Date": ["2021-01-01", "2022-02-02"]})
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+    assert pd.to_datetime("2021-01-01") in result["Date"].values
+    assert result["Date"].dtype == "datetime64[ns]"
+
+
+def test_datetime_with_timezone():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Date,               "datetime64[ns, US/Eastern]", True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": [1], "Date": ["2021-01-01T12:00:00"]})
+    result = enforce_schema(data=df, schema=SAMPLE_SCHEMA)
+    expected_date = pd.to_datetime("2021-01-01T12:00:00").tz_localize(ZoneInfo("US/Eastern"))
+    assert expected_date == result["Date"].dt.tz_convert("US/Eastern").item()
+    assert result["Date"].dtype == "datetime64[ns, US/Eastern]"
+
+
+def test_datetime_conversion_fail():
+    schema_csv = """
+        column_name,        dtype,                mandatory
+        Column1,            int64,                True
+        Date,               datetime64[ns],       True
+    """
+    SAMPLE_SCHEMA = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({"Column1": [1], "Date": ["not a date"]})
+    with pytest.raises(
+        pd._libs.tslibs.parsing.DateParseError,
+        match="^Failed to convert 'Date' to datetime64\\[ns\\]:",
+    ):
+        enforce_schema(data=df, schema=SAMPLE_SCHEMA)

--- a/tests/test_enforce_schema.py
+++ b/tests/test_enforce_schema.py
@@ -158,6 +158,29 @@ def test_keep_extra_columns():
     assert list(result.columns) == ["Column1", "Column3"]
 
 
+def test_sort_columns_behavior():
+    schema_csv = """
+        column,             dtype,                mandatory
+        ticker,             string[python],       True
+        price,              float64,              True
+    """
+    schema = pd.read_csv(StringIO(schema_csv), skipinitialspace=True)
+    df = pd.DataFrame({
+        'price': [150.0, 2800.0],
+        'ticker': ['AAPL', 'GOOGL']
+    })
+
+    result_sorted = enforce_schema(df, schema, sort_columns=True)
+    assert list(result_sorted.columns) == ['ticker', 'price'], (
+        "Columns are not sorted correctly with sort_columns=True."
+    )
+
+    result_unsorted = enforce_schema(df, schema, sort_columns=False)
+    assert list(result_unsorted.columns) == ['price', 'ticker'], (
+        "Columns should not be sorted with sort_columns=False."
+    )
+
+
 def test_dtype_conversion():
     schema_csv = """
         column,    dtype,     mandatory


### PR DESCRIPTION
### This PR covers changes for creating `enforce_schema()` function

**Description**:
The current `enforce_dtypes` method needs to be updated to support the new approach of using CSV-defined schemas. Instead of relying on separate `required` and `optional` column dictionaries, the method should now take two DataFrames:

1. **Data to enforce**: The DataFrame that requires schema validation and type enforcement.
2. **Schema DataFrame**: A DataFrame containing schema metadata (column names, dtypes, and whether they are mandatory) that will be used to enforce column presence and types.
