### PR TITLE
Improve data frame syntax with 'query'

### DIFF
--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -86,7 +86,7 @@ def enforce_schema(
 
 def _enforce_schema(data: pd.DataFrame, schema: pd.DataFrame) -> pd.DataFrame:
     if not data.empty:
-        missing_cols = set(schema.loc[schema["mandatory"], "column"]).difference(data.columns)
+        missing_cols = set(schema.query("mandatory")["column"]).difference(data.columns)
         if missing_cols:
             raise ValueError(f"Data frame is missing required columns: {missing_cols}")
 


### PR DESCRIPTION
Use the query command for more readably data frame syntax. Avoid df.loc[df["condition"]].