### PR TITLE
Feat: add copy_on_write rule

### DIFF
--- a/consistent_df/enforce_schema.py
+++ b/consistent_df/enforce_schema.py
@@ -6,6 +6,10 @@ from io import StringIO
 from zoneinfo import ZoneInfo
 
 
+# TODO: remove this rule when Pandas release the 3.0 version with default copy on write
+pd.options.mode.copy_on_write = True
+
+
 SCHEMA_CSV = """
     column,         dtype,     mandatory
     column,         str,       True


### PR DESCRIPTION
### PR Description: Enable Copy-on-Write Mode in Preparation for Pandas 3.0

**Summary:**
This PR prepares our codebase for the upcoming changes in pandas 3.0 by enabling the **Copy-on-Write** (CoW) mode. Pandas 3.0 will default to CoW, which means chained indexing will no longer function, and the **SettingWithCopyWarning** will become obsolete. 

**Details:**
- We set `pd.options.mode.copy_on_write = True` to activate CoW mode even before pandas 3.0 is officially available.
- Enabling CoW mode now allows us to:
  - Take advantage of performance improvements.
  - Proactively align our codebase with the new pandas default behavior, minimizing future adjustments.
  