### PR TITLE
Add polars utilities for schema enforcement and DataFrame conversion

### DIFF
--- a/consistent_df/__init__.py
+++ b/consistent_df/__init__.py
@@ -8,3 +8,7 @@ from .enforce_schema import enforce_schema
 from .nest import nest, unnest
 from .string import df_to_consistent_str
 from .testing import assert_frame_equal
+from .polars_utils import (  # noqa: F401
+    DTYPE_MAP, WARN_PANDAS_INPUT, enforce_schema as pl_enforce_schema,
+    ensure_polars, resolve_dtype, strip_whitespace, to_pandas, to_polars,
+)

--- a/consistent_df/polars_utils.py
+++ b/consistent_df/polars_utils.py
@@ -1,0 +1,311 @@
+"""Polars utilities for schema enforcement and DataFrame conversion.
+
+Schemas are polars DataFrames with columns: column, dtype, mandatory.
+The dtype column contains string names mapped to polars types via DTYPE_MAP.
+"""
+
+import re
+import warnings
+import polars as pl
+
+
+# Map dtype strings (from CSV schema definitions) to polars types.
+# Includes pandas-era names for backward compatibility with existing schemas.
+DTYPE_MAP = {
+    # Pandas-era names (used in existing schema CSVs)
+    "string[python]": pl.String,
+    "string": pl.String,
+    "str": pl.String,
+    "datetime64[ns]": pl.Date,
+    "boolean": pl.Boolean,
+    "bool": pl.Boolean,
+    "object": pl.Object,
+    "int": pl.Int64,
+    "int64": pl.Int64,
+    "Int64": pl.Int64,
+    "float": pl.Float64,
+    "float64": pl.Float64,
+    "Float64": pl.Float64,
+    # Polars-native names
+    "String": pl.String,
+    "Date": pl.Date,
+    "Boolean": pl.Boolean,
+}
+
+_DATETIME_TZ_RE = re.compile(r"datetime64\[ns,\s*(.+)\]")
+
+
+def resolve_dtype(dtype_str: str) -> pl.DataType:
+    """Resolve a dtype string to a polars DataType.
+
+    Checks DTYPE_MAP for static mappings, then handles timezone-aware
+    datetime strings like ``datetime64[ns, Europe/Berlin]``.
+
+    Args:
+        dtype_str: Dtype string from a schema definition.
+
+    Returns:
+        Corresponding polars DataType.
+
+    Raises:
+        ValueError: If the dtype string is not recognized.
+    """
+    if dtype_str in DTYPE_MAP:
+        return DTYPE_MAP[dtype_str]
+
+    m = _DATETIME_TZ_RE.fullmatch(dtype_str)
+    if m:
+        return pl.Datetime("ns", m.group(1))
+
+    raise ValueError(f"Unknown dtype string: '{dtype_str}'")
+
+
+def enforce_schema(
+    df: pl.DataFrame | None,
+    schema: pl.DataFrame,
+    keep_extra_columns: bool = False,
+    sort_columns: bool = False,
+) -> pl.DataFrame:
+    """Validate and conform a polars DataFrame to a schema.
+
+    Checks mandatory columns, adds missing optional columns as typed nulls,
+    and casts dtypes via polars ``cast(strict=False)``. Incompatible values
+    become null.
+
+    Args:
+        df: DataFrame to validate. None returns an empty DataFrame.
+        schema: Schema with columns: column, dtype, mandatory.
+        keep_extra_columns: If True, retain columns not in the schema.
+        sort_columns: If True, reorder columns to match schema order.
+
+    Returns:
+        DataFrame conforming to the schema.
+
+    Raises:
+        TypeError: If df is not a polars DataFrame or None.
+        ValueError: If mandatory columns are missing.
+    """
+    columns = schema["column"].to_list()
+    dtypes = {col: resolve_dtype(ds) for col, ds in schema.select("column", "dtype").iter_rows()}
+    mandatory = schema.filter(pl.col("mandatory"))["column"].to_list()
+
+    if df is None or (len(df) == 0 and len(df.columns) == 0):
+        return pl.DataFrame(schema=dtypes)
+
+    if not isinstance(df, pl.DataFrame):
+        raise TypeError(f"Expected pl.DataFrame or None, got {type(df).__name__}")
+
+    # Validate mandatory columns present
+    if len(df) > 0:
+        missing = set(mandatory) - set(df.columns)
+        if missing:
+            raise ValueError(f"Missing required columns: {sorted(missing)}")
+
+    # Add missing optional columns as typed nulls
+    df = df.with_columns(**{
+        col: pl.lit(None).cast(dtypes[col])
+        for col in columns if col not in df.columns
+    })
+
+    # Cast types: batch simple casts via df.cast(), handle String→Boolean
+    # and String→Date specially (polars can't cast these directly)
+    special_casts = {}
+    cast_map = {}
+    for col, dtype in dtypes.items():
+        if col not in df.columns or df[col].dtype == dtype:
+            continue
+        if dtype == pl.Object or isinstance(dtype, pl.List):
+            continue
+
+        if dtype == pl.Boolean and df[col].dtype == pl.String:
+            stripped = pl.col(col).str.strip_chars().str.to_lowercase()
+            special_casts[col] = (
+                pl.when(stripped == "true").then(True)
+                .when(stripped == "false").then(False)
+                .otherwise(None)
+            )
+        elif dtype == pl.Date and df[col].dtype == pl.String:
+            c = pl.col(col)
+            special_casts[col] = pl.coalesce(
+                c.str.to_date("%Y-%m-%d", strict=False),
+                c.str.to_date("%Y-%m", strict=False),
+                c.str.to_date("%Y", strict=False),
+            )
+        else:
+            cast_map[col] = dtype
+
+    if special_casts:
+        df = df.with_columns(**special_casts)
+    if cast_map:
+        df = df.cast(cast_map, strict=False)
+
+    # Column selection: drop extras and/or reorder to schema order
+    schema_col_set = set(columns)
+
+    if not keep_extra_columns:
+        df = df.drop([c for c in df.columns if c not in schema_col_set])
+    if sort_columns:
+        ordered = [c for c in columns if c in df.columns]
+        extra = [c for c in df.columns if c not in schema_col_set]
+        df = df.select(ordered + extra)
+
+    return df
+
+
+def strip_whitespace(df: pl.DataFrame) -> pl.DataFrame:
+    """Strip whitespace from column names and string values.
+
+    Converts empty strings to null. Useful at CSV read boundaries
+    where fixed-width formatting adds padding.
+
+    Args:
+        df: DataFrame to clean.
+
+    Returns:
+        DataFrame with stripped names and values.
+    """
+    rename_map = {c: c.strip() for c in df.columns if c != c.strip()}
+
+    if rename_map:
+        df = df.rename(rename_map)
+
+    str_cols = [c for c in df.columns if df[c].dtype == pl.String]
+
+    if str_cols:
+        df = df.with_columns(**{
+            c: pl.col(c).str.strip_chars().replace("", None)
+            for c in str_cols
+        })
+
+    return df
+
+
+# Migration flag: set to True to emit DeprecationWarning when callers pass
+# pandas DataFrames to public methods. Flip before changing pandas=True
+# defaults, so external consumers have time to migrate their input data.
+WARN_PANDAS_INPUT = False
+
+
+def ensure_polars(data, func_name: str = ""):
+    """Convert input to polars DataFrame, warning on pandas input if enabled.
+
+    Use at the entry of public methods that accept DataFrames from external
+    callers. When ``WARN_PANDAS_INPUT`` is True, emits DeprecationWarning
+    for pandas input so callers can migrate.
+
+    Args:
+        data: Input data in any supported format.
+        func_name: Function name for the deprecation warning message.
+
+    Returns:
+        Normalized polars DataFrame, or None if data is None.
+    """
+    import pandas as pd
+
+    if isinstance(data, pd.DataFrame) and WARN_PANDAS_INPUT:
+        warnings.warn(
+            f"{func_name}: pandas DataFrame input is deprecated, use polars",
+            DeprecationWarning, stacklevel=3
+        )
+
+    return to_polars(data)
+
+
+def to_polars(data) -> pl.DataFrame | None:
+    """Normalize input to a polars DataFrame.
+
+    Accepts None, pl.DataFrame, pd.DataFrame, pd.Series, dict, or list
+    of dicts. Returns None for None or empty list.
+
+    Args:
+        data: Input data in any supported format.
+
+    Returns:
+        Normalized polars DataFrame, or None.
+
+    Raises:
+        TypeError: If the input type is not supported.
+    """
+    if data is None:
+        return None
+    if isinstance(data, pl.DataFrame):
+        return data
+
+    import pandas as pd
+    import numpy as np
+
+    def _sanitize(d):
+        return {
+            k: (None if v is pd.NaT or v is pd.NA
+                or (isinstance(v, float) and np.isnan(v)) else v)
+            for k, v in d.items()
+        }
+
+    if isinstance(data, pd.DataFrame):
+        try:
+            return pl.from_pandas(data)
+        except OverflowError:
+            # Object columns with values that overflow Int64
+            data = data.copy()
+            for col in data.columns:
+                if data[col].dtype == object:
+                    data[col] = data[col].astype(pd.StringDtype())
+
+            return pl.from_pandas(data)
+
+    if isinstance(data, pd.Series):
+        if data.name is not None:
+            return pl.from_pandas(data.to_frame().reset_index(drop=True))
+
+        return pl.DataFrame([_sanitize(data.to_dict())])
+
+    if isinstance(data, dict):
+        data = _sanitize(data)
+        if any(isinstance(v, (list, tuple)) for v in data.values()):
+            return pl.DataFrame(data)
+
+        return pl.DataFrame([data])
+
+    if isinstance(data, list):
+        if len(data) == 0:
+            return None
+        data = [
+            _sanitize(item.to_dict()) if isinstance(item, pd.Series)
+            else (_sanitize(item) if isinstance(item, dict) else item)
+            for item in data
+        ]
+
+        return pl.DataFrame(data)
+
+    raise TypeError(f"Expected DataFrame or dict, got {type(data).__name__}")
+
+
+def to_pandas(df: pl.DataFrame, schema: pl.DataFrame = None):
+    """Convert a polars DataFrame to pandas with correct nullable dtypes.
+
+    Reads dtype strings from the schema to restore exact pandas types
+    (e.g., ``string[python]`` → ``pd.StringDtype("python")``).
+
+    Args:
+        df: Polars DataFrame to convert.
+        schema: Schema with column and dtype columns.
+            If None, uses default polars-to-pandas conversion.
+
+    Returns:
+        Pandas DataFrame with correct nullable dtypes.
+    """
+    result = df.to_pandas()
+
+    if schema is not None:
+        dtype_map = dict(schema.select("column", "dtype").iter_rows())
+        for col in result.columns:
+            dtype_str = dtype_map.get(col)
+            if dtype_str:
+                try:
+                    result[col] = result[col].astype(dtype_str)
+                except (ValueError, TypeError):
+                    warnings.warn(
+                        f"to_pandas: failed to cast column '{col}' to {dtype_str}"
+                    )
+
+    return result

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/macxred/consistent_df',
     author="Lukas Elmiger, Oleksandr Stepanenko",
     python_requires='>3.9',
-    install_requires=['pandas'],
+    install_requires=['pandas', 'polars'],
     packages=find_packages(exclude=('tests', 'examples')),
     extras_require={
         "dev": [

--- a/tests/test_polars_utils.py
+++ b/tests/test_polars_utils.py
@@ -1,0 +1,277 @@
+"""Unit tests for polars utilities in consistent_df.polars_utils."""
+
+import datetime
+import pandas as pd
+import polars as pl
+import pytest
+from io import StringIO
+from consistent_df.polars_utils import (
+    enforce_schema, ensure_polars, resolve_dtype,
+    strip_whitespace, to_pandas, to_polars,
+)
+
+
+# --- resolve_dtype ---
+
+class TestResolveDtype:
+
+    def test_static_mappings(self):
+        assert resolve_dtype("string[python]") == pl.String
+        assert resolve_dtype("datetime64[ns]") == pl.Date
+        assert resolve_dtype("Int64") == pl.Int64
+        assert resolve_dtype("Float64") == pl.Float64
+        assert resolve_dtype("boolean") == pl.Boolean
+        assert resolve_dtype("bool") == pl.Boolean
+        assert resolve_dtype("Date") == pl.Date
+        assert resolve_dtype("String") == pl.String
+
+    def test_timezone_aware_datetime(self):
+        result = resolve_dtype("datetime64[ns, Europe/Berlin]")
+        assert result == pl.Datetime("ns", "Europe/Berlin")
+
+    def test_timezone_aware_utc(self):
+        result = resolve_dtype("datetime64[ns, UTC]")
+        assert result == pl.Datetime("ns", "UTC")
+
+    def test_unknown_dtype_raises(self):
+        with pytest.raises(ValueError, match="Unknown dtype string"):
+            resolve_dtype("unknown_type")
+
+
+# --- enforce_schema ---
+
+class TestEnforceSchema:
+
+    @staticmethod
+    def _make_schema(csv_text):
+        return pl.read_csv(StringIO(csv_text))
+
+    def test_none_input(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\namount,Float64,true\n"
+        )
+        result = enforce_schema(None, schema)
+        assert result.columns == ["account", "amount"]
+        assert len(result) == 0
+        assert result["account"].dtype == pl.String
+        assert result["amount"].dtype == pl.Float64
+
+    def test_empty_dataframe(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\nname,String,true\nvalue,Int64,false\n"
+        )
+        result = enforce_schema(pl.DataFrame(), schema)
+        assert result.columns == ["name", "value"]
+        assert len(result) == 0
+
+    def test_missing_mandatory_column(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\namount,Float64,true\n"
+        )
+        df = pl.DataFrame({"account": ["A"]})
+        with pytest.raises(ValueError, match="Missing required columns"):
+            enforce_schema(df, schema)
+
+    def test_missing_optional_column_added(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\nnotes,String,false\n"
+        )
+        df = pl.DataFrame({"account": ["A", "B"]})
+        result = enforce_schema(df, schema)
+        assert "notes" in result.columns
+        assert result["notes"].null_count() == 2
+
+    def test_type_cast(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\nid,Int64,true\nvalue,Float64,true\n"
+        )
+        df = pl.DataFrame({"id": [1, 2], "value": [10, 20]})
+        result = enforce_schema(df, schema)
+        assert result["value"].dtype == pl.Float64
+
+    def test_string_to_boolean_cast(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\nflag,boolean,true\n"
+        )
+        df = pl.DataFrame({"flag": ["true", "false", "True", "FALSE", None]})
+        result = enforce_schema(df, schema)
+        assert result["flag"].dtype == pl.Boolean
+        assert result["flag"].to_list() == [True, False, True, False, None]
+
+    def test_string_to_date_cast(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\ndate,datetime64[ns],true\n"
+        )
+        df = pl.DataFrame({"date": ["2024-01-15", "2024-06-30"]})
+        result = enforce_schema(df, schema)
+        assert result["date"].dtype == pl.Date
+        assert result["date"].to_list() == [
+            datetime.date(2024, 1, 15), datetime.date(2024, 6, 30)
+        ]
+
+    def test_drop_extra_columns(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\n"
+        )
+        df = pl.DataFrame({"account": ["A"], "extra": [1]})
+        result = enforce_schema(df, schema)
+        assert "extra" not in result.columns
+
+    def test_keep_extra_columns(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\n"
+        )
+        df = pl.DataFrame({"account": ["A"], "extra": [1]})
+        result = enforce_schema(df, schema, keep_extra_columns=True)
+        assert "extra" in result.columns
+
+    def test_sort_columns(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\nfirst,String,true\nsecond,Int64,true\n"
+        )
+        df = pl.DataFrame({"second": [1], "first": ["A"]})
+        result = enforce_schema(df, schema, sort_columns=True)
+        assert result.columns == ["first", "second"]
+
+    def test_invalid_input_type(self):
+        schema = self._make_schema(
+            "column,dtype,mandatory\naccount,String,true\n"
+        )
+        with pytest.raises(TypeError, match="Expected pl.DataFrame or None"):
+            enforce_schema({"account": ["A"]}, schema)
+
+
+# --- strip_whitespace ---
+
+class TestStripWhitespace:
+
+    def test_strip_column_names(self):
+        df = pl.DataFrame({"  name  ": ["A"], " value ": [1]})
+        result = strip_whitespace(df)
+        assert result.columns == ["name", "value"]
+
+    def test_strip_string_values(self):
+        df = pl.DataFrame({"name": ["  Alice  ", "  Bob  "]})
+        result = strip_whitespace(df)
+        assert result["name"].to_list() == ["Alice", "Bob"]
+
+    def test_empty_string_to_null(self):
+        df = pl.DataFrame({"name": ["Alice", "  ", ""]})
+        result = strip_whitespace(df)
+        assert result["name"].to_list() == ["Alice", None, None]
+
+    def test_non_string_columns_unchanged(self):
+        df = pl.DataFrame({"name": ["Alice"], "value": [42]})
+        result = strip_whitespace(df)
+        assert result["value"].to_list() == [42]
+
+
+# --- to_polars ---
+
+class TestToPolars:
+
+    def test_none_returns_none(self):
+        assert to_polars(None) is None
+
+    def test_polars_passthrough(self):
+        df = pl.DataFrame({"a": [1, 2]})
+        assert to_polars(df) is df
+
+    def test_pandas_dataframe(self):
+        pdf = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        result = to_polars(pdf)
+        assert isinstance(result, pl.DataFrame)
+        assert result["a"].to_list() == [1, 2]
+        assert result["b"].to_list() == ["x", "y"]
+
+    def test_pandas_preserves_datetime_as_datetime(self):
+        """Generic to_polars does NOT cast Datetime→Date (pyledger-specific)."""
+        pdf = pd.DataFrame({"ts": pd.to_datetime(["2024-01-01", "2024-06-15"])})
+        result = to_polars(pdf)
+        assert str(result["ts"].dtype).startswith("Datetime")
+
+    def test_pandas_series_named(self):
+        s = pd.Series([1, 2, 3], name="val")
+        result = to_polars(s)
+        assert isinstance(result, pl.DataFrame)
+        assert "val" in result.columns
+
+    def test_pandas_series_unnamed(self):
+        s = pd.Series({"a": 1, "b": 2})
+        result = to_polars(s)
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 1
+
+    def test_dict_single_row(self):
+        result = to_polars({"a": 1, "b": "x"})
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 1
+
+    def test_dict_columnar(self):
+        result = to_polars({"a": [1, 2], "b": ["x", "y"]})
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 2
+
+    def test_list_of_dicts(self):
+        result = to_polars([{"a": 1}, {"a": 2}])
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 2
+
+    def test_empty_list_returns_none(self):
+        assert to_polars([]) is None
+
+    def test_sanitizes_nat(self):
+        result = to_polars({"a": pd.NaT, "b": 1})
+        assert result["a"].to_list() == [None]
+
+    def test_sanitizes_nan(self):
+        result = to_polars({"a": float("nan"), "b": 1})
+        assert result["a"].to_list() == [None]
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError, match="Expected DataFrame or dict"):
+            to_polars(42)
+
+
+# --- to_pandas ---
+
+class TestToPandas:
+
+    def test_basic_conversion(self):
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        result = to_pandas(df)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result["a"]) == [1, 2]
+
+    def test_schema_dtype_restoration(self):
+        schema = pl.DataFrame({
+            "column": ["name", "value"],
+            "dtype": ["string[python]", "Int64"],
+            "mandatory": [True, True],
+        })
+        df = pl.DataFrame({"name": ["Alice"], "value": [42]})
+        result = to_pandas(df, schema)
+        assert result["name"].dtype == pd.StringDtype("python")
+        assert result["value"].dtype == pd.Int64Dtype()
+
+    def test_no_schema(self):
+        df = pl.DataFrame({"a": [1.0, 2.0]})
+        result = to_pandas(df)
+        assert isinstance(result, pd.DataFrame)
+
+
+# --- ensure_polars ---
+
+class TestEnsurePolars:
+
+    def test_passes_through_polars(self):
+        df = pl.DataFrame({"a": [1]})
+        assert ensure_polars(df) is df
+
+    def test_converts_pandas(self):
+        pdf = pd.DataFrame({"a": [1]})
+        result = ensure_polars(pdf)
+        assert isinstance(result, pl.DataFrame)
+
+    def test_none_returns_none(self):
+        assert ensure_polars(None) is None


### PR DESCRIPTION
## Summary
- Add `polars_utils` module with shared utilities for the polars migration across macxred packages
- Includes `DTYPE_MAP`, `resolve_dtype()`, `enforce_schema()`, `strip_whitespace()`, `to_polars()`, `to_pandas()`, `ensure_polars()`
- 38 new tests covering all functions

## Test plan
- [x] All 38 new tests pass
- [x] All pre-existing tests still pass (3 pre-existing failures due to missing `tzdata` package, unrelated)
- [x] flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)